### PR TITLE
restore permissions of brew-managed directories

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,10 @@ then
 	sudo installer  -pkg osxfuse/Install\ OSXFUSE\ 2.5.pkg -target  /
 	hdiutil detach osxfuse
 	rm -f $OSXFUSE.dmg
+	
+	# OSXFuse changes permissions to some brew-managed directories; clean that up:
+	sudo chown $USER:admin /usr/local/include
+	sudo chown $USER:admin /usr/local/lib/pkgconfig
 fi
 
 cp encfsmacosxfuse.rb /usr/local/Library/Formula/


### PR DESCRIPTION
Installing OSXFuse changes the permissions of

/usr/local/include and /usr/local/lib/pkgconfig

to root:wheel. This change restores them to $USER:admin.
