### PR TITLE
Not mounting to Dropbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Example
 
 If you want to use it for your Dropbox Documents directory you could use it like this:
 
-    encfs ~/Dropbox/Documents.encfs ~/Dropbox/Documents.secure -- -o volname="Documents"
+    encfs ~/Dropbox/Documents.encfs ~/Documents.secure -- -o volname="Documents"


### PR DESCRIPTION
I am not sure it's wise to mount it to folder that gets shared on Dropbox. 

That would share the "plaintext" immediately, removing any reason for having encfs in the first place.
